### PR TITLE
Some improvements to the v5 page

### DIFF
--- a/docs/botmaking/config-file-documenation.md
+++ b/docs/botmaking/config-file-documenation.md
@@ -105,11 +105,11 @@ All of these default to the "normal" value (the first in the list) if you don't 
 - participant_config_NUMBER:  The path to a participant configuration
 - participant_team_NUMBER: what team the bot is on
 - participant_type_NUMBER: the type of the bot Accepted values are "human", "rlbot", "psyonix", "party_member_bot", and "controller_passthrough", You can have up to 4 local humans and they must be activated in game or it will crash. If no player is specified you will be spawned in as spectator!
-  - human - not controlled by the framework (but must appear before bot entries)
-  - rlbot - controlled by the framework
-  - psyonix - default bots (skill level can be changed with participant_bot_skill
-  - party_member_bot - controlled by an rlbot but the game detects it as a human
-  - controller_passthrough - controlled by a human but runs through the framework
+    - human - not controlled by the framework (but must appear before bot entries)
+    - rlbot - controlled by the framework
+    - psyonix - default bots (skill level can be changed with participant_bot_skill
+    - party_member_bot - controlled by an rlbot but the game detects it as a human
+    - controller_passthrough - controlled by a human but runs through the framework
 - participant_bot_skill_NUMBER: 0.0 is Rookie, 0.5 is pro, 1.0 is all-star
 - participant_loadout_config_NUMBER: the path to the loadout.   This overrides the agent config if not None
 

--- a/docs/botmaking/manipulating-game-state.md
+++ b/docs/botmaking/manipulating-game-state.md
@@ -5,9 +5,9 @@ We have a feature that lets you set exact positions, velocities, etc. for the ba
 ### Possibilities
 
 - Set up a specific scenario for your bot to try over and over. Better than custom training, because:
-  - You have control over car orientation, velocity, angular velocity, and boost amount
-  - You can do it in the middle of an exhibition match with opponents
-  - You can control it all from inside your bot code
+    - You have control over car orientation, velocity, angular velocity, and boost amount
+    - You can do it in the middle of an exhibition match with opponents
+    - You can control it all from inside your bot code
 - Build training sets for machine learning
 - Record snapshots during a game and "rewind" if you encounter a natural situation you want to iterate on
 - Hover your car in midair while you work on your orientation code

--- a/docs/botmaking/shooting-the-ball-towards-or-away-from-a-target.md
+++ b/docs/botmaking/shooting-the-ball-towards-or-away-from-a-target.md
@@ -5,12 +5,12 @@ This tutorial is based on the systems used by [VirxERLU](https://github.com/Virx
 ### TOC
 
 - [This tutorial is NOT language-specific!](#this-tutorial-is-not-language-specific)
-  - [TOC](#toc)
-  - [Targets and anti-targets](#targets-and-anti-targets)
-  - [Direction of approach](#direction-of-approach)
-  - [Ball location offset](#ball-location-offset)
-  - [Aligning with the direction of approach](#aligning-with-the-direction-of-approach)
-  - [Driving](#driving)
+    - [TOC](#toc)
+    - [Targets and anti-targets](#targets-and-anti-targets)
+    - [Direction of approach](#direction-of-approach)
+    - [Ball location offset](#ball-location-offset)
+    - [Aligning with the direction of approach](#aligning-with-the-direction-of-approach)
+    - [Driving](#driving)
 
 ### Targets and anti-targets
 

--- a/docs/botmaking/team-match-communication-protocol.md
+++ b/docs/botmaking/team-match-communication-protocol.md
@@ -40,8 +40,8 @@ This is what a packet following TMCP looks like:
 
 - `tmcp_version`
 
-  - Major: Breaking revision number
-  - Minor: Non-breaking revision number
+    - Major: Breaking revision number
+    - Minor: Non-breaking revision number
 
 - `team` - The team of the bot that sent the packet. 0 for blue and 1 for orange. This will be removed once match comms allow for team-only communication.
 

--- a/docs/botmaking/useful-game-values.md
+++ b/docs/botmaking/useful-game-values.md
@@ -47,8 +47,8 @@ Big boost pads:
 - Gives 100 boost.
 - Takes 10 seconds to refresh.
 - The pads with a z-component of 73.0 are the big pads. Mirror these coordinates to get all 6:
-  - Midfield: (3584, 0)
-  - Corner: (3072, 4096)
+    - Midfield: (3584, 0)
+    - Corner: (3072, 4096)
 
 A car picks up a boost pad if the car's center of mass (not hitbox) enters the pad's hitbox. This interaction is different when cars are standing still (see the [Rocket Science video on boost pad hitboxes](https://www.youtube.com/watch?v=xgfa-qZyInw))
 
@@ -131,17 +131,17 @@ More information on car bodies [in this spreadsheet](https://onedrive.live.com/v
 (e.g. 2778 uu/s = 100 km/h)
 
 - Gravity: 650 uu/s^2
-  - "Low" mutator: 325 uu/s^2
-  - "High" mutator: 1137.5 uu/s^2
-  - "Super High" mutator: 3250 uu/s^2
+    - "Low" mutator: 325 uu/s^2
+    - "High" mutator: 1137.5 uu/s^2
+    - "Super High" mutator: 3250 uu/s^2
 
 ### Ball
 
 - Radius: 91.25 uu
 - Max speed: 6000 uu/s
-  - "Slow" mutator: 1500 uu/s
-  - "Fast" mutator: 9000 uu/s
-  - "Super Fast" mutator: 15000 uu/s
+    - "Slow" mutator: 1500 uu/s
+    - "Fast" mutator: 9000 uu/s
+    - "Super Fast" mutator: 15000 uu/s
 - Mass: 30.0 (unit is arbitrary)
 - Coefficient of restitution: 60% (it loses 40% of the component of its velocity that's toward the surface)
 - Maximum ball angular velocity: 6.0 radians/s
@@ -154,28 +154,28 @@ More information on car bodies [in this spreadsheet](https://onedrive.live.com/v
 - Car mass: 180.0 (unit is arbitrary)
 - Boost consumption rate: 33.3/s
 - Boost acceleration:
-  - on the ground: 991.666 uu/s^2
-  - in the air: 1058.333 uu/s^2
+    - on the ground: 991.666 uu/s^2
+    - in the air: 1058.333 uu/s^2
 - Acceleration in the ground:
-  - due to throttle: depends on velocity - https://samuelpmish.github.io/notes/RocketLeague/ground_control/#throttle
-  - due to braking (any amount): -3500.0 uu/s^2
-  - due to slowing during zero-throttle coasting: -525.0 uu/s^2
+    - due to throttle: depends on velocity - https://samuelpmish.github.io/notes/RocketLeague/ground_control/#throttle
+    - due to braking (any amount): -3500.0 uu/s^2
+    - due to slowing during zero-throttle coasting: -525.0 uu/s^2
 - Acceleration in the air due to throttle: ~66.667 uu/s^2   (yes, throttling accelerates the car in the air)
 - [Jumping](/botmaking/jumping-physics)
 - Double jump
-  - An instantaneous velocity increase of ~291.667 uu/s in the direction of your roof.
+    - An instantaneous velocity increase of ~291.667 uu/s in the direction of your roof.
 - Minimum and maximum rotation (in radians):
-  - Pitch: \[-pi/2, pi/2\]
-  - Yaw: \[-pi, pi\]
-  - Roll: \[-pi, pi\]
+    - Pitch: \[-pi/2, pi/2\]
+    - Yaw: \[-pi, pi\]
+    - Roll: \[-pi, pi\]
 - Maximum car angular acceleration:
-  - Yaw: 9.11 radians/s^2
-  - Pitch: 12.46 radians/s^2
-  - Roll: 38.34 radians/s^2
+    - Yaw: 9.11 radians/s^2
+    - Pitch: 12.46 radians/s^2
+    - Roll: 38.34 radians/s^2
 - Maximum car angular velocity: 5.5 radians/s
 - Turning
-  - Turning in Rocket League is very complex and not a lot is known. Hopefully, the numbers below can help you out a bit!
-  - Turn radius: https://samuelpmish.github.io/notes/RocketLeague/ground_control/#turning. Python implementation:
+    - Turning in Rocket League is very complex and not a lot is known. Hopefully, the numbers below can help you out a bit!
+    - Turn radius: https://samuelpmish.github.io/notes/RocketLeague/ground_control/#turning. Python implementation:
 
 ```python
 def turn_radius(v):
@@ -201,9 +201,9 @@ def curvature(v):
 
 - No matter if you're accelerating or decelerating, (as the throttle is 1) the car's turn radius and velocity balance out so the car turns 90 degrees in about 0.775 seconds, 180 degrees in 1.55 seconds, and 360 degrees in 3.1 seconds.
 - Accelerating while turning (starting from a standstill with throttle and steer set to 1)
-  - While turning with steer set to 1 (or -1), the maximum forwards velocity the car can reach is around 1234. It reaches this after 5 seconds.
+    - While turning with steer set to 1 (or -1), the maximum forwards velocity the car can reach is around 1234. It reaches this after 5 seconds.
 
-  - The speed of the car after x time can be estimated with the following equation: `1234 * (1 - e ^ [-{time / 0.74704}])`
+    - The speed of the car after x time can be estimated with the following equation: `1234 * (1 - e ^ [-{time / 0.74704}])`
 
     ![Graph of the velocity while turning starting from 0](/img/useful-game-values/car1.png)
 
@@ -225,9 +225,9 @@ def get_turn_time_from_speed(speed):
 ```
 
 - Decelerating while turning (starting from the top speed with throttle and steer set to 1)
-  - While turning with steer set to 1 (or -1), the minimum forward velocity the car can reach is around 1234. It reaches this after 7.5 seconds.
+    - While turning with steer set to 1 (or -1), the minimum forward velocity the car can reach is around 1234. It reaches this after 7.5 seconds.
 
-  - The speed and time can both be estimated with linear piecewise functions. The blue lines is the real velocity, and the orange line is the velocity that is predicted by the piecewise.
+    - The speed and time can both be estimated with linear piecewise functions. The blue lines is the real velocity, and the orange line is the velocity that is predicted by the piecewise.
 
     ![Graph of the velocity while turning starting from 2300](/img/useful-game-values/car2.png)
 

--- a/docs/community/rlbot-pack.md
+++ b/docs/community/rlbot-pack.md
@@ -7,8 +7,8 @@ To be a part of the pack, you just need to create a pull request with your bot t
 To qualify:
 
 - Your bot must be capable of auto-run
-  - Use Python or Rust? You're all set.
-  - Other languages? We have a [Java wiki](https://github.com/RLBot/RLBotJavaExample/wiki/Auto-Launching-Java), a [C# wiki](https://github.com/RLBot/RLBotCSharpExample/wiki/Auto-Launching) and a [Scratch video](https://www.youtube.com/watch?v=4oK44syo49Y).
+    - Use Python or Rust? You're all set.
+    - Other languages? We have a [Java wiki](https://github.com/RLBot/RLBotJavaExample/wiki/Auto-Launching-Java), a [C# wiki](https://github.com/RLBot/RLBotCSharpExample/wiki/Auto-Launching) and a [Scratch video](https://www.youtube.com/watch?v=4oK44syo49Y).
 - Your bot must not have any crazy external requirements (except for very common ones like Java or Google Chrome)
 - You must be willing to trim out any extra bot configs from your folder that people wouldn't care about
 - Obey the [guidelines](/community-guidelines)

--- a/docs/community/tips-for-running-tournaments.md
+++ b/docs/community/tips-for-running-tournaments.md
@@ -56,7 +56,7 @@ You should test all the bots beforehand.
 
 - Do they start successfully?
 - Do they have any obvious behavior problems that might be a problem with your setup?
-  - Feel free to check with the bot maker about the expected behavior.
+    - Feel free to check with the bot maker about the expected behavior.
 - Do they run properly on *both* blue and orange team? Consider running test matches of each bot vs itself.
 - Are the C#/Java bots running on different ports? Each C# and Java bot must run on a separate port from the rest of the bots.
 

--- a/docs/framework/psyonix-api-notes.md
+++ b/docs/framework/psyonix-api-notes.md
@@ -12,13 +12,13 @@ We're aiming for a backwards compatibility with this first bot API release, so e
 
 - The renderer now has occlusion, so 3D lines disappear behind objects correctly!
 - You can still use state setting, except:
-  - Can’t manipulate boost pads
-  - Can’t mess with the car’s jump state
-  - Can’t provide partial location / velocity, must fully specify
+    - Can’t manipulate boost pads
+    - Can’t mess with the car’s jump state
+    - Can’t provide partial location / velocity, must fully specify
 - The GameTickPacket will have all the same data except:
-  - It will have non-interpolated values straight from the physics engine, same as RigidBodyTick!
-  - Latest ball touch will always be blank for now (fixed)
-  - Boost respawn timers don't work yet
+    - It will have non-interpolated values straight from the physics engine, same as RigidBodyTick!
+    - Latest ball touch will always be blank for now (fixed)
+    - Boost respawn timers don't work yet
 - Unfortunately, quick chat is not supported yet (1/2 fixed)
 - We only support Soccer, exhibition mode at the moment. (More modes are supported)
 - The game data will currently update in memory at 60Hz, ~~regardless of Rocket League's frame rate~~ (anecdotally it seems to be capped at the frame rate). We may be able to tune that later. (We now have 120hz)
@@ -31,8 +31,8 @@ We're aiming for a backwards compatibility with this first bot API release, so e
 - Support for Linux and macOS is planned! (C++ and C# bots won't work)
 - Rumble support is planned. Bots will be able to take part in the mayhem! (Done)
 - Unrelated to the API:
-  - DomNomNom is working on a team communication system for bots. (Done)
-  - Chip is working on advanced pathfinding for bots.
+    - DomNomNom is working on a team communication system for bots. (Done)
+    - Chip is working on advanced pathfinding for bots.
 
 ## Regarding Bugs
 

--- a/docs/framework/v5.md
+++ b/docs/framework/v5.md
@@ -1,16 +1,16 @@
 # RLBot v5 (Beta) Overview
 
-RLBot v5 is the next major update to the RLBot framework bringing a host of reliability improvements and some new features to the table.
+RLBot v5 is the next major version of the RLBot framework bringing a host of reliability improvements and some new features to the table.
 
 RLBot v5 is now in beta.
 In this beta period we will fix bugs, incorporate feedback, and potentially make minor breaking changes.
-However, RLBot v5 should now be feature-complete and people can start adopting it.
+However, RLBot v5 is now about feature-complete and people can start adopting it.
 Note that the various language interfaces are currently in development and may be unstable.
 There is also no GUI and distribution method yet.
 You can find the newest version of `RLBotServer.exe` on [github.com/RLBot/core/releases](https://github.com/RLBot/core/releases).
-See [Virx' Video](https://github.com/VirxEC/python-interface/wiki/Migration) on how to get started in RLBot v5 beta with Python.
+See [Virx' Video](https://youtu.be/GLqvodQ942A?si=WVnwyEpThDVnhqYu) on how to get started in RLBot v5 beta with Python.
 
-Any updates to RLBot v5 beta and language interfaces will be announced in the [RLBot Discord #annoucements](https://discord.com/channels/348658686962696195/352588748401410049) channel.
+Any updates to RLBot v5 beta and the language interfaces will be announced in the [RLBot Discord #annoucements](https://discord.com/channels/348658686962696195/352588748401410049) channel.
 
 - If you find bugs, please report them on [Github](https://github.com/RLBot/core/issues).
 - If you run into issues with v5, you can find help on Discord, either in the appropriate [language channel](https://discord.com/channels/348658686962696195/446761380654219264) or in the [#framework-dev](https://discord.com/channels/348658686962696195/423167304956903428) channel.
@@ -21,15 +21,15 @@ In the remainder of this document we will cover:
 
 - Our reasoning for creating v5 and an overview of its architecture,
 - A list of features completed/reworked/todo/removed in v5 (beta),
-- A guide on how to transition from v4 to v5,
+- A guide on breaking changes and how to transition from v4 to v5,
 - Links to v5 language interfaces and more.
 
 
 ## Why v5?
 
-RLBot v4 has been the most userfriendly and stable version of RLBot yet.
+RLBot v4 has been incredible userfriendly, feature rich, and stable.
 It was made in 2018 when RLBot was still using DLL injection.
-Later, in 2019, the collaboration with Psyonix and the official API were revealed.
+Later, in 2019, the collaboration with Psyonix and the official API were incorporated.
 Since then, there have only been minor changes and new features, which proves how well-designed v4 was.
 In fact, v5 is not that different from v4.
 It is primarily a rewrite and an opportunity fix the flaws of v4 that have been revealed over the years.
@@ -37,25 +37,26 @@ So here are the main reasons we made v5:
 
 - The closed-sourced part of v4 is doing more than just communication with the Psyonix API.
   This has long prevented the community from fixing certain bugs themselves.
-  Therefore we are extracting part of the closed-source part into the opens-source part of RLBot such that only the communication is closed-source.
+  Therefore we are extracting that functionality into the opens-source part of RLBot such that only the closed-source part is only about communication with the API.
 - The closed-sourced part of v4 is written in C++.
   By rewritting the backend of RLBot in C# we hope that more people feel comfortable contributing to it.
 - No more DLLs. You may not be aware, but most bots still uses a DLL to communicate directly to the RLBot backend.
   In v5, the transition to web sockets is finally complete and this allows the bot inferfaces to be improved (e.g. Python type hints are not a hack anymore).
-- All languages can start matches in v4, technically, but the logic for launching of Rocket League and bots was only implemented in Python (and partially Rust).
-  This discourage us from writing match starters (GUI, autoleague, etc) in other languages than Python (even CleoPetra in Java uses a Python process to start matches).
-  Therefore we move this logic to the backend for v5 such that more languages can benefit from it.
+- All languages can start matches in v4, but the logic for launching of Rocket League and bots was only implemented in Python (and partially Rust).
+  This discourage people from writing match starters (GUI, autoleague, etc) in other languages than Python (even CleoPetra written in Java uses a Python process to start matches).
+  Therefore we are moving this logic to the backend for v5 such that more languages can benefit from it.
+- We are releasing ourselves from design choices made under restrictions of the DLL injection.
 - The Psyonix API made a few extra features availble to us, but we never integrated them in v4. They are integerated in v5.
 - Python is very slow. The rewrite in C# has made this clear.
 - The `.cfg` file format has no standard.
 
-So while the changes to the functionality and interface are minor, the architecture and the framework's interal code is very different.
+So while the changes to the functionality and interface are minor, the architecture and the framework's internal code is very different.
 We hope these changes will make it enjoyable to work with and contribute to RLBot moving forward.
 
 
 ## Features of v5
 
-Legend: ✅=done, 🟨=todo, ✨=new, 🛠=reworked/changed, ⛔=removed
+[Legend: ✅=done, 🟨=todo, ✨=new, 🛠=reworked/changed, ⛔=removed]
 
 - ✅🛠 First-class Windows & Linux support
     - No current plans for MacOS, as there's no way to run Rocket League without a full VM
@@ -122,133 +123,12 @@ On top of all that, the framework is also simply significantly faster.
 
 ## Breaking Changes / Migration
 
-Many things will feel familiar in v5, but there's several breaking changes that have been made:
-
-- `RLBot.exe` has been renamed to `RLBotServer.exe`.
-    - Instead of the entire binary being closed-source, as much of the code as possible is now open-source
-    in [RLBot/core](https://github.com/RLBot/core).
-    - Anyone can build `RLBotServer.exe` after making changes to the code due to `Bridge.dll` - this binary is
-    closed-source due to legal restrictions around the Psyonix API, but this knew binary was built to be as minimal
-    as possible while adhering to those restrictions.
-- All bots are now expected to run at 120hz. If you need more time to process inputs, it's advisable to
-    engineer your bot around this by, for example, using an extra asynchronous thread running complex algorithms.
-- Config files have changed
-    - Instead of the arbitrary `cfg` file format, we now use `toml` files. This is a standardized format that
-    is easier to read and write and has better support over different languages. Many IDEs also support syntax
-    highlighting for `toml` files.
-    - Bots config files _must_ end in `bot.toml`. This includes hiveminds. Example valid file names include:
-        - `bot.toml`
-        - `super_bot.bot.toml`
-        - `super_ultra.bot.toml`
-    - Script config files _must_ end in `script.toml`. Example valid file names include:
-        - `script.toml`
-        - `super_script.script.toml`
-        - `super_ultra.script.toml`
-    - Other config files have no defined naming convention.
-    - Bot/Script/Hivemind config file format:
-        - `[Locations]` has been renamed to `[settings]`
-        - `hivemind` must be set to `true` instead of `[settings]` if the bot is a hivemind
-        - `python_file`, `requirements_file`, `supports_standalone`, and `use_virtual_environment` have been replaced
-        with a different concept: `run_command` and `run_command_linux` are ran in a shell to start the bot.
-            - Note: Bots submitted to the v5 botpack (TODO) will be expected to be packagable in a self-contained
-            executable that is built from source by an automated deployment pipeline. This includes Python bots.
-        - New optional value `location` - will set the working directory to something other than the directory that
-          the config file is currently located in.
-        - `maximum_tick_rate_preference` has been removed, every bot is expected to run at 120hz
-        - `supports_early_start` has been removed, as all bots are booted as soon as possible. Bots no longer know
-        their index when booting, but they do know their name & team.
-        - `looks_config` and `loadout_generator` have been replaced with `loadout_config`
-            - If `loadout_config` is not set, then your bot can send a `SetLoadout` message during boot-up. This is a
-        direct replacement for the old loadout generator script.
-        - `[Details]` has been renamed to `[details]`
-        - `github` has been renamed to `source_link`
-        - Example of a bot config file in v4 and v5:
-
-          v4:
-
-          ```cfg
-          [Locations]
-          name = Necto
-          logo_file = ./necto_logo.png
-          looks_config = ./appearance.cfg
-          python_file = ./bot.py
-          requirements_file = ./requirements.txt
-          maximum_tick_rate_preference = 120
-
-          [Details]
-          developer = Rolv, Soren, and several contributors
-          description = Necto is the official RLGym community bot, trained using PPO with workers run by people all around the world.
-          fun_fact = Necto uses an attention mechanism, commonly used for text understanding, to support any number of players
-          github = https://github.com/Rolv-Arild/Necto
-          language = rlgym
-          tags = 1v1, teamplay
-          ```
-
-          v5:
-
-          ```toml
-          [settings]
-          name = "Necto"
-          logo_file = "necto_logo.png"
-          loadout_config = "loadout.toml"
-          run_command = ".\\venv\\Scripts\\python bot.py"
-          run_command_linux = "./venv/bin/python bot.py"
-
-          [details]
-          developer = "Rolv, Soren, and several contributors"
-          description = "Necto is the official RLGym community bot, trained using PPO with workers run by people all around the world."
-          fun_fact = "Necto uses an attention mechanism, commonly used for text understanding, to support any number of players"
-          source_link = "https://github.com/Rolv-Arild/Necto"
-          language = "rlgym"
-          tags = ["1v1", "teamplay"]
-          ```
-
-- _All processes_ (bot, script & hivemind) are now similar to v4's concept of a `StandaloneBot`
-    - This means that the only way to interface with `RLBotServer.exe` is by communicating via FlatBuffers over
-    a TCP socket. By default, the server listens to `0.0.0.0:23234`. The port can be changed by passing in the
-    desired port as the first argument when starting the binary, for example `RLBotServer.exe 54315`.
-    - In Python specifically, there is no longer a `BaseAgent` class. Instead, you must implement the `Bot` class.
-    - Must read the environment variable `RLBOT_SERVER_PORT` to know what port they can connect to the server on.
-    - Must read the environment variable `RLBOT_SPAWN_IDS`. It will be a single integer for bots and scripts, but for
-  hiveminds it will be a comma separated list of integers.
-- Various changes have been made to the `GameTickPacket`
-    - Removed `num_cars`/`num_pads` as the list of cars/pads is now only as long as the actual number of cars/pads
-    - Renamed `cars` to `players`
-    - Replaced `ball` with `balls` which is now a list of balls in the game
-    - Note: This list _can_ have a length of zero in a normal match. It's recommended to check the length of
-      the list before assuming there's a ball in the game.
-    - In `PlayerInfo`:
-        - Replaced `is_demolished` with `demolished_timeout`: `demolished_timeout` is a float representing the time
-          until the player respawns after being demolished. It is zero if the player is not demolished.
-        - Added `dodge_timeout`: A float representing the time the player has left before they can no longer dodge.
-          `-1` if the player cannot dodge (e.g. because they're on the ground or the dodge time window expired).
-        - Replaced `has_wheel_contact` with a new concept, `AirState`. `AirState` is defined as:
-
-          ```cpp
-          enum AirState: ubyte {
-            /// All wheels are on the ground
-            OnGround,
-            /// When the bot is jumping,
-            /// then InAir right after
-            Jumping,
-            /// When the bot is double jumping,
-            /// then InAir right after
-            DoubleJumping,
-            /// When the bot is dodging,
-            /// then InAir right after
-            Dodging,
-            InAir,
-          }
-          ```
-
-        - Removed `jumped` and `double_jumped`
-
-The above list may be incomplete.
+The migration guide for the Python interface gives a good overview of the breaking changes and what to do instead so we refer to that: https://github.com/VirxEC/python-interface/wiki/Migration
 
 
 ## Links and Resources
 
-Below we list where to find the implementation of RLBot v5, the language interfaces, and related documentation.
+Below you can find links to the implementation of RLBot v5, the language interfaces, and related documentation.
 This wiki will also be updated as things stabilize.
 
 **RLBot v5 framework:**

--- a/docs/framework/v5.md
+++ b/docs/framework/v5.md
@@ -27,23 +27,23 @@ In the remainder of this document we will cover:
 
 ## Why v5?
 
-RLBot v4 has been incredible userfriendly, feature rich, and stable.
+RLBot v4 has been incredibly userfriendly, feature rich, and stable.
 It was made in 2018 when RLBot was still using DLL injection.
-Later, in 2019, the collaboration with Psyonix and the official API were incorporated.
+Later, in 2019, the collaboration with Psyonix and the official API were introduced.
 Since then, there have only been minor changes and new features, which proves how well-designed v4 was.
 In fact, v5 is not that different from v4.
 It is primarily a rewrite and an opportunity fix the flaws of v4 that have been revealed over the years.
 So here are the main reasons we made v5:
 
-- The closed-sourced part of v4 is doing more than just communication with the Psyonix API.
+- The closed-source part of v4 is doing more than just communication with the Psyonix API.
   This has long prevented the community from fixing certain bugs themselves.
-  Therefore we are extracting that functionality into the opens-source part of RLBot such that only the closed-source part is only about communication with the API.
-- The closed-sourced part of v4 is written in C++.
+  Therefore we are extracting that functionality into the open-source part of RLBot, making the closed-source part exclusively about communication with the API.
+- The closed-source part of v4 is written in C++.
   By rewritting the backend of RLBot in C# we hope that more people feel comfortable contributing to it.
 - No more DLLs. You may not be aware, but most bots still uses a DLL to communicate directly to the RLBot backend.
   In v5, the transition to web sockets is finally complete and this allows the bot inferfaces to be improved (e.g. Python type hints are not a hack anymore).
 - All languages can start matches in v4, but the logic for launching of Rocket League and bots was only implemented in Python (and partially Rust).
-  This discourage people from writing match starters (GUI, autoleague, etc) in other languages than Python (even CleoPetra written in Java uses a Python process to start matches).
+  This discouraged people from writing match starters (GUI, autoleague, etc) in other languages than Python (even CleoPetra written in Java uses a Python process to start matches).
   Therefore we are moving this logic to the backend for v5 such that more languages can benefit from it.
 - We are releasing ourselves from design choices made under restrictions of the DLL injection.
 - The Psyonix API made a few extra features availble to us, but we never integrated them in v4. They are integerated in v5.

--- a/docs/framework/v5.md
+++ b/docs/framework/v5.md
@@ -19,10 +19,10 @@ Any updates to RLBot v5 beta and the language interfaces will be announced in th
 
 In the remainder of this document we will cover:
 
-- Our reasoning for creating v5 and an overview of its architecture,
-- A list of features completed/reworked/todo/removed in v5 (beta),
-- A guide on breaking changes and how to transition from v4 to v5,
-- Links to v5 language interfaces and more.
+- Our reasoning for creating v5 and an overview of its architecture [->](#why-v5),
+- A list of features completed/reworked/todo/removed in v5 (beta) [->](#features-of-v5),
+- A guide on breaking changes and how to transition from v4 to v5 [->](#breaking-changes-migration),
+- Links to v5 language interfaces and more [->](#links-and-resources).
 
 
 ## Why v5?


### PR DESCRIPTION
Fixes some typos and rephrases sentences.

Replaces the migration section with a reference to the Python language migration page as it is more up-to-date.

Also includes indentation fixes for all pages.