### PR TITLE
Add 'edit' button, repo link, more socials, etc

### DIFF
--- a/docs/botmaking/input-and-output-data.md
+++ b/docs/botmaking/input-and-output-data.md
@@ -1,5 +1,3 @@
-# Input and Output Data (current)
-
 All supported languages have access to the same data, though syntax and conventions will vary. It is controlled by this specification: [rlbot.fbs](https://github.com/RLBot/RLBot/blob/master/src/main/flatbuffers/rlbot.fbs)
 
 Language-specific guides:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,8 @@
 # Overview
 
+!!! note "RLBot v5 is in beta!"
+	Learn more about v5 in the [RLBot v5 Overview](/framework/v5) and start converting your bot today!
+
 Welcome to the RLBot wiki!
 RLBot is a framework for creating offline Rocket League bots.
 The framework uses an official Psyonix API making our bots safe to play with and against.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
-# RLBot
+# Overview
 
 Welcome to the RLBot wiki!
+RLBot is a framework for creating offline Rocket League bots.
+The framework uses an official Psyonix API making our bots safe to play with and against.
+This wiki primarily houses resources for bot development, but you can also find guides for users, framework documentation, and community insights.
 
 ## Getting Started
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,15 @@
 site_name: RLBot Wiki
+site_url: https://wiki.rlbot.org/
+repo_name: RLBot/RLBot
+repo_url: https://github.com/RLBot/RLBot
+edit_uri: https://github.com/RLBot/wiki/edit/main/docs/
 
 theme:
   name: material
   logo: assets/rlbot-logo.svg
   favicon: assets/rlbot-logo.svg
+  icon:
+    repo: fontawesome/brands/github
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
@@ -21,18 +27,36 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
 
+  features:
+    # Expand nav folders by default
+    - navigation.expand
+    # Enable the footer
+    - navigation.footer
+    # Auto hide the header after scrolling
+    - header.autohide
+    - content.action.edit
+
 extra:
   social:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/zbaAKPt
     - icon: fontawesome/brands/github
       link: https://github.com/RLBot
+    - icon: fontawesome/brands/youtube
+      link: https://www.youtube.com/RLBotOfficial
+    - icon: fontawesome/brands/twitter
+      link: https://x.com/RLBotOfficial
+    - icon: fontawesome/brands/twitch
+      link: https://www.twitch.tv/rlbotofficial
 
 extra_css:
   - stylesheets/extra.css
 
 markdown_extensions:
+  - admonition
+  - pymdownx.critic
+  - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       use_pygments: true
-  - pymdownx.superfences 
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ theme:
     - navigation.expand
     # Enable the footer
     - navigation.footer
-    # Enagled 'Edit this page' button
+    # Enale 'Edit this page' button
     - content.action.edit
 
 extra:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,12 +28,11 @@ theme:
         name: Switch to light mode
 
   features:
-    # Expand nav folders by default
+    # Expand navigation folders by default
     - navigation.expand
     # Enable the footer
     - navigation.footer
-    # Auto hide the header after scrolling
-    - header.autohide
+    # Enagled 'Edit this page' button
     - content.action.edit
 
 extra:
@@ -54,9 +53,11 @@ extra_css:
 
 markdown_extensions:
   - admonition
+  # Code block features
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
       use_pygments: true
+  # Enable code blocks in multiple language
   - pymdownx.superfences


### PR DESCRIPTION
Found some advanced features on https://flatbuffers.dev/ and https://www.mkdocs.org/user-guide/configuration/ that would benefit our wiki:

- Add 'Edit this page' button for easier editing
- Add link to RLBot/RLBot repo in the top right (showing stars and forks too)
- Add more links to our social media in footer
- Topics on the left are now expanded by default
- Add footer where you can go back and forth between pages like a book
- Enabled [admonitions](https://python-markdown.github.io/extensions/admonition/) for highlighted notes and more

Sneak peak:
![image](https://github.com/user-attachments/assets/832451b1-9133-44d0-a67b-e122fcc982e2)
